### PR TITLE
support db config file for development environment.

### DIFF
--- a/scripts/bin/install_db_dev.sh
+++ b/scripts/bin/install_db_dev.sh
@@ -19,6 +19,26 @@ log(){
 
 log "Installing MVCCC database schema..."
 
+# read from db config file if it exists
+if [ -z $1 ]
+then
+    filename=../../dev_config/database.cfg
+else
+	filename=$1
+fi
+echo $filename
+echo
+if [ -f $filename ]
+then
+	echo -n "Reading db configuration from database config file .."
+	echo
+	source $filename
+	log "config host: $defaultHost"
+	log "config port: $defaultPort"
+	log "config user: $defaultUsername"
+	log "config path: $defaultMysqlPath"
+fi
+
 # Read MySQL server host
 echo -n "MySQL server host [$defaultHost]:"
 read host

--- a/scripts/bin/uninstall_db_dev.sh
+++ b/scripts/bin/uninstall_db_dev.sh
@@ -18,6 +18,26 @@ log(){
 
 log "Uninstalling MVCCC database schema..."
 
+# read from db config file if it exists
+if [ -z $1 ]
+then
+    filename=../../dev_config/database.cfg
+else
+	filename=$1
+fi
+echo $filename
+echo
+if [ -f $filename ]
+then
+	echo -n "Reading db configuration from database config file .."
+	echo
+	source $filename
+	log "config host: $defaultHost"
+	log "config port: $defaultPort"
+	log "config user: $defaultUsername"
+	log "config path: $defaultMysqlPath"
+fi
+
 # Read MySQL server host
 echo -n "MySQL server host [$defaultHost]:"
 read host


### PR DESCRIPTION
when using uninstall and install scripts, you could specify a database config file as a command line argument. Or it will look for ${SITE_DIR}/dev_config/database.cfg file if no argument. The database.cfg file should like this:
defaultHost="localhost"
defaultPort="8889"
defaultUsername="root"
defaultMysqlPath="/Applications/MAMP/Library/bin/"

Add a line in .git/info/exclude file to let git ignore the config dir:
 # git ls-files --others --exclude-from=.git/info/exclude
 # Lines that start with '#' are comments.
 # For a project mostly in C, the following would be a good set of
 # exclude patterns (uncomment them if you want to use them):
 # *.[oa]
 # *~
 .DS_Store
 dev_config/
